### PR TITLE
Drupal 10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "bex/behat-step-time-logger": "^2.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "drupal/core-dev": "^9",
-        "drupal/devel": "^4.0",
+        "drupal/devel": "^5.0 || ^4.0",
         "edgedesign/phpqa": "^1.23",
         "metadrop/behat-contexts": "^1.0",
         "metadrop/grumphp-drupal-check": "^0",


### PR DESCRIPTION
The required ["drupal/devel"](https://www.drupal.org/project/devel) package needs a version "^5.0" to be compatible with the Drupal 10 version.